### PR TITLE
Validate recipient wallet address

### DIFF
--- a/__tests__/pages/api/groups/[id]/recipients/[recipient_id]/update_recipient.test.ts
+++ b/__tests__/pages/api/groups/[id]/recipients/[recipient_id]/update_recipient.test.ts
@@ -173,7 +173,7 @@ describe(`PUT ${ENDPOINT}`, () => {
           data: {
             groupId: group.id,
             displayName: 'Homer Jay Simpson',
-            walletAddress: '0xDEADBEEF',
+            walletAddress: 'TCLJzGqHZFPYMCPAdEUJxGH1wXVkef8aHJ',
           },
         })
       })
@@ -182,7 +182,7 @@ describe(`PUT ${ENDPOINT}`, () => {
         it('returns error', async () => {
           const { req, res } = mockPUTRequestWithQuery(
             { id: group.id, recipient_id: recipient.id },
-            {},
+            { wallet_address: recipient.walletAddress },
             sessionToken
           )
 
@@ -200,7 +200,7 @@ describe(`PUT ${ENDPOINT}`, () => {
         it('returns error', async () => {
           const { req, res } = mockPUTRequestWithQuery(
             { id: group.id, recipient_id: recipient.id },
-            { display_name: 1 },
+            { display_name: 1, wallet_address: recipient.walletAddress },
             sessionToken
           )
 
@@ -220,7 +220,7 @@ describe(`PUT ${ENDPOINT}`, () => {
         it('returns error', async () => {
           const { req, res } = mockPUTRequestWithQuery(
             { id: group.id, recipient_id: recipient.id },
-            { display_name: ' ' },
+            { display_name: ' ', wallet_address: recipient.walletAddress },
             sessionToken
           )
 
@@ -240,7 +240,7 @@ describe(`PUT ${ENDPOINT}`, () => {
         it('returns error', async () => {
           const { req, res } = mockPUTRequestWithQuery(
             { id: group.id, recipient_id: recipient.id },
-            { display_name: ' 1 ' },
+            { display_name: ' 1 ', wallet_address: recipient.walletAddress },
             sessionToken
           )
 
@@ -256,12 +256,87 @@ describe(`PUT ${ENDPOINT}`, () => {
         })
       })
 
+      describe('when wallet_address is missing', () => {
+        it('returns error', async () => {
+          const { req, res } = mockPUTRequestWithQuery(
+            { id: group.id, recipient_id: recipient.id },
+            { display_name: recipient.displayName },
+            sessionToken
+          )
+
+          await handler(req, res)
+
+          expect(res._getStatusCode()).toBe(422)
+          expect(parseJSON(res)).toEqual({
+            success: false,
+            validation_errors: ['Wallet address: Required'],
+          })
+        })
+      })
+
+      describe('when wallet_address is not a string', () => {
+        it('returns error', async () => {
+          const { req, res } = mockPUTRequestWithQuery(
+            { id: group.id, recipient_id: recipient.id },
+            { display_name: recipient.displayName, wallet_address: 1 },
+            sessionToken
+          )
+
+          await handler(req, res)
+
+          expect(res._getStatusCode()).toBe(422)
+          expect(parseJSON(res)).toEqual({
+            success: false,
+            validation_errors: [
+              'Wallet address: Expected string, received number',
+            ],
+          })
+        })
+      })
+
+      describe('when wallet_address is an empty string', () => {
+        it('returns error', async () => {
+          const { req, res } = mockPUTRequestWithQuery(
+            { id: group.id, recipient_id: recipient.id },
+            { display_name: recipient.displayName, wallet_address: ' ' },
+            sessionToken
+          )
+
+          await handler(req, res)
+
+          expect(res._getStatusCode()).toBe(422)
+          expect(parseJSON(res)).toEqual({
+            success: false,
+            validation_errors: ['Wallet address: Invalid wallet address'],
+          })
+        })
+      })
+
+      describe('when wallet_address is an invalid address', () => {
+        it('returns error', async () => {
+          const { req, res } = mockPUTRequestWithQuery(
+            { id: group.id, recipient_id: recipient.id },
+            { display_name: recipient.displayName, wallet_address: '0xabc' },
+            sessionToken
+          )
+
+          await handler(req, res)
+
+          expect(res._getStatusCode()).toBe(422)
+          expect(parseJSON(res)).toEqual({
+            success: false,
+            validation_errors: ['Wallet address: Invalid wallet address'],
+          })
+        })
+      })
+
       describe('when salary is a negative number', () => {
         it('returns error', async () => {
           const { req, res } = mockPUTRequestWithQuery(
             { id: group.id, recipient_id: recipient.id },
             {
               display_name: 'Homer Jay Simpson',
+              wallet_address: recipient.walletAddress,
               salary: -1,
             },
             sessionToken
@@ -285,6 +360,7 @@ describe(`PUT ${ENDPOINT}`, () => {
             { id: group.id, recipient_id: recipient.id },
             {
               display_name: 'Homer Jay Simpson',
+              wallet_address: recipient.walletAddress,
               salary: 0.1,
             },
             sessionToken
@@ -317,7 +393,7 @@ describe(`PUT ${ENDPOINT}`, () => {
             groupId: group.id,
             displayName: 'Homer Jay Simpson',
             comment: 'Technical supervisor',
-            walletAddress: '0xDEADBEEF',
+            walletAddress: 'TCLJzGqHZFPYMCPAdEUJxGH1wXVkef8aHJ',
             contacts: 'Homer_Simpson@AOL.com',
             salary: 35,
           },
@@ -330,6 +406,7 @@ describe(`PUT ${ENDPOINT}`, () => {
             { id: group.id, recipient_id: recipient.id },
             {
               display_name: ' Bart ',
+              wallet_address: recipient.walletAddress,
             },
             sessionToken
           )
@@ -344,7 +421,9 @@ describe(`PUT ${ENDPOINT}`, () => {
           expect(response.data.id).not.toBeEmpty()
           expect(response.data.display_name).toEqual('Bart')
           expect(response.data.comment).toEqual('Technical supervisor')
-          expect(response.data.wallet_address).toEqual('0xDEADBEEF')
+          expect(response.data.wallet_address).toEqual(
+            'TCLJzGqHZFPYMCPAdEUJxGH1wXVkef8aHJ'
+          )
           expect(response.data.contacts).toEqual('Homer_Simpson@AOL.com')
           expect(response.data.salary).toEqual(35)
           expect(response.data.created_at).toEqual(
@@ -364,7 +443,7 @@ describe(`PUT ${ENDPOINT}`, () => {
             {
               display_name: ' Bart Simpson ',
               comment: ' Son ',
-              wallet_address: ' 0xBEE ',
+              wallet_address: ' TCLJzGqHZFPYMCPAdEUJxGH1wXVkef8aHJ ',
               contacts: ' Bart@AOL.com ',
               salary: 42,
             },
@@ -381,7 +460,9 @@ describe(`PUT ${ENDPOINT}`, () => {
           expect(response.data.id).not.toBeEmpty()
           expect(response.data.display_name).toEqual('Bart Simpson')
           expect(response.data.comment).toEqual('Son')
-          expect(response.data.wallet_address).toEqual('0xBEE')
+          expect(response.data.wallet_address).toEqual(
+            'TCLJzGqHZFPYMCPAdEUJxGH1wXVkef8aHJ'
+          )
           expect(response.data.contacts).toEqual('Bart@AOL.com')
           expect(response.data.salary).toEqual(42)
           expect(response.data.created_at).toEqual(

--- a/__tests__/pages/api/groups/[id]/recipients/add_recipient.test.ts
+++ b/__tests__/pages/api/groups/[id]/recipients/add_recipient.test.ts
@@ -123,7 +123,7 @@ describe(`POST ${ENDPOINT}`, () => {
         it('returns error', async () => {
           const { req, res } = mockPOSTRequestWithQuery(
             { id: group.id },
-            {},
+            { wallet_address: 'TCLJzGqHZFPYMCPAdEUJxGH1wXVkef8aHJ' },
             sessionToken
           )
 
@@ -145,6 +145,7 @@ describe(`POST ${ENDPOINT}`, () => {
             },
             {
               display_name: 1,
+              wallet_address: 'TCLJzGqHZFPYMCPAdEUJxGH1wXVkef8aHJ',
             },
             sessionToken
           )
@@ -169,6 +170,7 @@ describe(`POST ${ENDPOINT}`, () => {
             },
             {
               display_name: ' ',
+              wallet_address: 'TCLJzGqHZFPYMCPAdEUJxGH1wXVkef8aHJ',
             },
             sessionToken
           )
@@ -193,6 +195,7 @@ describe(`POST ${ENDPOINT}`, () => {
             },
             {
               display_name: ' 1 ',
+              wallet_address: 'TCLJzGqHZFPYMCPAdEUJxGH1wXVkef8aHJ',
             },
             sessionToken
           )
@@ -209,6 +212,95 @@ describe(`POST ${ENDPOINT}`, () => {
         })
       })
 
+      describe('when wallet_address is missing', () => {
+        it('returns error', async () => {
+          const { req, res } = mockPOSTRequestWithQuery(
+            { id: group.id },
+            { display_name: ' Homer Jay Simpson ' },
+            sessionToken
+          )
+
+          await handler(req, res)
+
+          expect(res._getStatusCode()).toBe(422)
+          expect(parseJSON(res)).toEqual({
+            success: false,
+            validation_errors: ['Wallet address: Required'],
+          })
+        })
+      })
+
+      describe('when wallet_address is not a string', () => {
+        it('returns error', async () => {
+          const { req, res } = mockPOSTRequestWithQuery(
+            {
+              id: group.id,
+            },
+            {
+              display_name: ' Homer Jay Simpson ',
+              wallet_address: 1,
+            },
+            sessionToken
+          )
+
+          await handler(req, res)
+
+          expect(res._getStatusCode()).toBe(422)
+          expect(parseJSON(res)).toEqual({
+            success: false,
+            validation_errors: [
+              'Wallet address: Expected string, received number',
+            ],
+          })
+        })
+      })
+
+      describe('when wallet_address is an empty string', () => {
+        it('returns error', async () => {
+          const { req, res } = mockPOSTRequestWithQuery(
+            {
+              id: group.id,
+            },
+            {
+              display_name: ' Homer Jay Simpson ',
+              wallet_address: ' ',
+            },
+            sessionToken
+          )
+
+          await handler(req, res)
+
+          expect(res._getStatusCode()).toBe(422)
+          expect(parseJSON(res)).toEqual({
+            success: false,
+            validation_errors: ['Wallet address: Invalid wallet address'],
+          })
+        })
+      })
+
+      describe('when wallet_address is an invalid address', () => {
+        it('returns error', async () => {
+          const { req, res } = mockPOSTRequestWithQuery(
+            {
+              id: group.id,
+            },
+            {
+              display_name: ' Homer Jay Simpson ',
+              wallet_address: '0xabc',
+            },
+            sessionToken
+          )
+
+          await handler(req, res)
+
+          expect(res._getStatusCode()).toBe(422)
+          expect(parseJSON(res)).toEqual({
+            success: false,
+            validation_errors: ['Wallet address: Invalid wallet address'],
+          })
+        })
+      })
+
       describe('when salary is a negative number', () => {
         it('returns error', async () => {
           const { req, res } = mockPOSTRequestWithQuery(
@@ -217,6 +309,7 @@ describe(`POST ${ENDPOINT}`, () => {
             },
             {
               display_name: 'Homer Jay Simpson',
+              wallet_address: 'TCLJzGqHZFPYMCPAdEUJxGH1wXVkef8aHJ',
               salary: -1,
             },
             sessionToken
@@ -242,6 +335,7 @@ describe(`POST ${ENDPOINT}`, () => {
             },
             {
               display_name: 'Homer Jay Simpson',
+              wallet_address: 'TCLJzGqHZFPYMCPAdEUJxGH1wXVkef8aHJ',
               salary: 0.1,
             },
             sessionToken
@@ -278,6 +372,7 @@ describe(`POST ${ENDPOINT}`, () => {
             },
             {
               display_name: ' Homer Jay Simpson ',
+              wallet_address: 'TCLJzGqHZFPYMCPAdEUJxGH1wXVkef8aHJ',
             },
             sessionToken
           )
@@ -292,7 +387,9 @@ describe(`POST ${ENDPOINT}`, () => {
           expect(response.data.id).not.toBeEmpty()
           expect(response.data.display_name).toEqual('Homer Jay Simpson')
           expect(response.data.comment).toBeNull()
-          expect(response.data.wallet_address).toBeNull()
+          expect(response.data.wallet_address).toEqual(
+            'TCLJzGqHZFPYMCPAdEUJxGH1wXVkef8aHJ'
+          )
           expect(response.data.contacts).toBeNull()
           expect(response.data.salary).toEqual(0)
           expect(response.data.created_at).not.toBeEmpty()
@@ -310,7 +407,7 @@ describe(`POST ${ENDPOINT}`, () => {
             {
               display_name: ' Homer Jay Simpson ',
               comment: ' Technical supervisor ',
-              wallet_address: ' 0xDEADBEEF ',
+              wallet_address: 'TCLJzGqHZFPYMCPAdEUJxGH1wXVkef8aHJ',
               contacts: ' Homer_Simpson@AOL.com ',
               salary: 42,
             },
@@ -327,7 +424,9 @@ describe(`POST ${ENDPOINT}`, () => {
           expect(response.data.id).not.toBeEmpty()
           expect(response.data.display_name).toEqual('Homer Jay Simpson')
           expect(response.data.comment).toEqual('Technical supervisor')
-          expect(response.data.wallet_address).toEqual('0xDEADBEEF')
+          expect(response.data.wallet_address).toEqual(
+            'TCLJzGqHZFPYMCPAdEUJxGH1wXVkef8aHJ'
+          )
           expect(response.data.contacts).toEqual('Homer_Simpson@AOL.com')
           expect(response.data.salary).toEqual(42)
           expect(response.data.created_at).not.toBeEmpty()

--- a/src/lib/types/tronweb.d.ts
+++ b/src/lib/types/tronweb.d.ts
@@ -1,0 +1,3 @@
+declare module 'tronweb' {
+  export function isAddress(_address: string): boolean
+}

--- a/src/validations/index.ts
+++ b/src/validations/index.ts
@@ -1,3 +1,4 @@
+import { isAddress } from 'tronweb'
 import { z } from 'zod'
 
 const GroupSchema = z.object({
@@ -11,7 +12,12 @@ export const UpdateGroupSchema = GroupSchema
 const RecipientSchema = z.object({
   display_name: z.string().trim().min(2),
   comment: z.string().trim().optional(),
-  wallet_address: z.string().trim().optional(),
+  wallet_address: z
+    .string()
+    .trim()
+    .refine((value) => isAddress(value), {
+      message: 'Invalid wallet address',
+    }),
   contacts: z.string().trim().optional(),
   salary: z.coerce.number().nonnegative().int().optional(),
 })


### PR DESCRIPTION
- wallet address is required for recipients now.
- due to no official typescript support for tronweb, declared it as module in tronweb.d.ts file  
![Screenshot from 2023-06-25 17-53-14](https://github.com/optriment/web3-employment/assets/65503300/68de4a55-f80a-49ce-ae0b-ad71aaf1cdc8)
